### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ FROM ubuntu:latest
 ARG DEBIAN_FRONTEND=noninteractive
 
 #install dependencies
-RUN apt-get update && apt-get install -y nodejs npm nano && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y nodejs npm nano mongo-tools && rm -rf /var/lib/apt/lists/*
 
 #Add non-root user, add installation directories and assign proper permissions
 RUN mkdir -p /opt/meshcentral


### PR DESCRIPTION
Adds the mongo-tools package which includes the mongodump tool, fixing issue #4, and assisting those of us who'd like use this container alongside a mongodb container, ex issue #2